### PR TITLE
Fix signature of handle_super in rtf parser

### DIFF
--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -632,7 +632,7 @@ class Group(object):
     def handle_up(self, amount):
         self.content.append(ReadableMarker("super", True))
 
-    def handle_super(self, amount):
+    def handle_super(self):
         self.content.append(ReadableMarker("super", True))
 
     #Turns off superscripting or subscripting


### PR DESCRIPTION
No argument is allowed for \super (like for \sub, contrary to \up and \dn).
(This has already been fixed in the python2 version.)